### PR TITLE
Calling _destroy directly because we're on node 6

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,6 @@ function createClient(port, host, opts, connectionListener) {
 
     let socket = net.createConnection(port, host, () => {
         socket.setTimeout(0);
-        client.connect(connectionListener);
     });
 
     socket.setTimeout(20000);

--- a/src/sessionControlClient.js
+++ b/src/sessionControlClient.js
@@ -440,7 +440,7 @@ class SessionControlClient extends EventEmitter {
 
         this.autoRevision = null;
 
-        this.ll.destroy();
+        this.ll._destroy();
         this.stream.end();
 
         this.emit("close", err);


### PR DESCRIPTION
destroy doesn't exist so we need to call _destroy directly (this isn't good) for now.