### PR TITLE
propagate retry errors from linklayer to sessioncontrolclient

### DIFF
--- a/src/linkLayer.js
+++ b/src/linkLayer.js
@@ -364,7 +364,7 @@ class LinkLayer extends Duplex {
         }
     }
 
-    _destroy() {
+    _destroy(err, cb) {
         debug("LinkLayer _destroy");
 
         clearTimeout(this.timer);
@@ -382,6 +382,8 @@ class LinkLayer extends Duplex {
         destroyStream(this.opSerializer);
         destroyStream(this.midParser);
         destroyStream(this.midSerializer);
+
+        cb(err);
     }
 
     finishCycle(err) {

--- a/src/sessionControlClient.js
+++ b/src/sessionControlClient.js
@@ -980,8 +980,7 @@ class SessionControlClient extends EventEmitter {
         this.request("keepAlive", (err) => {
             if (err) {
                 debug('SessionControlClient _sendKeepAlive response-error', err);
-                clearTimeout(this.keepAliveTimer);
-                this.close();
+                process.nextTick(() => this.close());
             }
         });
     }


### PR DESCRIPTION
this stops the promise/callback from `sessioncontrolclient.command(...)` from hanging indefinitely if the controller does not respond after retrying

the change to `_sendKeepAlive` fixes a minor reentrancy issue where otherwise the error wouldn't be passed to `sessioncontrolclient.close()`